### PR TITLE
Extend the Buffer prototype with buffertools.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var fs = require('fs')
  * Patch the Buffer class to add methods such as concat().
  */
 
-require('buffertools');
+require('buffertools').extend();
 
 /**
  * Create a log parser.


### PR DESCRIPTION
A recent change to buffertools modified the default behavior such that the `Buffer` prototype is _no longer_ extended by default.

This PR ensures the `Buffer` prototype is extended in `index.js`.

See https://github.com/bnoordhuis/node-buffertools/commit/20b192152d398b2d5b301f00d1e5daa22f6f2e23.
