### PR TITLE
remove buffertools dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var fs = require('fs')
-  , spawn = require('child_process').spawn
-  , buffertools = require('buffertools');
+  , spawn = require('child_process').spawn;
 
 /**
  * Create a log parser.
@@ -95,7 +94,7 @@ Parser.prototype.stdin = function (iterator, callback) {
 Parser.prototype.stream = function (stream, iterator, callback) {
     var self = this, overflow = new Buffer(0), complete = false;
     stream.on('data', function (data) {
-        var buffer = buffertools.concat(overflow, data), newline = 0;
+        var buffer = Buffer.concat(overflow, data), newline = 0;
         for (var i = 0, len = buffer.length; i < len; i++) {
             if (buffer[i] === 10) {
                 self.parseLine(buffer.slice(newline, i), iterator);

--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
     "type": "git",
     "url": "http://github.com/chriso/nginx-parser.git"
   },
-  "engines": { "node": ">=0.4.0" },
-  "dependencies": {
-    "buffertools": "2.1.3"
-  },
+  "engines": { "node": ">=0.7.11" },
   "licenses": [{
     "type": "MIT",
     "url": "http://github.com/chriso/nginx-parser/raw/master/LICENSE"


### PR DESCRIPTION
Hi @chriso , I am using nginxparser on a project that is installed on windows machines that do not have development tools installed. nginxparser only use buffertool to concat buffers, which is doable with the native `Buffer` class since v0.7.11. Removing buffertools make the installation easier and quicker (no need to compile buffertools)