### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ Parser.prototype.stdin = function (iterator, callback) {
 Parser.prototype.stream = function (stream, iterator, callback) {
     var self = this, overflow = new Buffer(0), complete = false;
     stream.on('data', function (data) {
-        var buffer = Buffer.concat(overflow, data), newline = 0;
+        var buffer = Buffer.concat([overflow, data]), newline = 0;
         for (var i = 0, len = buffer.length; i < len; i++) {
             if (buffer[i] === 10) {
                 self.parseLine(buffer.slice(newline, i), iterator);


### PR DESCRIPTION
bug fix: buffer.js:309
    throw new TypeError('"list" argument must be an Array of Buffers');
    ^

TypeError: "list" argument must be an Array of Buffers
    at Function.Buffer.concat (buffer.js:309:11)
    at ReadStream.<anonymous> (/root/utils/node_modules/nginxparser/index.js:100:29)
    at emitOne (events.js:96:13)
    at ReadStream.emit (events.js:189:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at ReadStream.Readable.push (_stream_readable.js:134:10)
    at onread (fs.js:1925:12)
    at FSReqWrap.wrapper [as oncomplete] (fs.js:627:17)